### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@
 
 name: Build and installation tests
 
+# Restrict permissions at top-level to 'read' as a minimal explicit permission.
+permissions:
+  contents: read
+
 on:
   push:
     branches: ['master', 'devel']

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,6 +1,11 @@
 # This workflow will run some regression tests.
 name: Regression Tests
 
+# Restrict permissions at top-level to 'read' as a minimal explicit permission.
+# This will apply to all jobs that do not define their own permissions.
+permissions:
+  contents: read
+
 on:
   push:
     branches: ['master', 'devel']
@@ -69,8 +74,8 @@ jobs:
         if-no-files-found: ignore
   
   Jupyter:
-    # Building the Jupyter book is not really a regression test. However, it has to be in this workflow due to the handling of 
-    # the artifacts.
+    # Building the Jupyter book is not really a regression test, but it makes sure that the notebooks are still working.
+    # In addition, it has to be in this workflow due to the handling of the artifacts.
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -106,8 +111,6 @@ jobs:
         if-no-files-found: ignore
   
   combine-pages:
-    permissions:
-      contents: read
     runs-on: ubuntu-latest
     # Add a dependency to the build job
     needs: [Jupyter, Pytest]

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -106,6 +106,8 @@ jobs:
         if-no-files-found: ignore
   
   combine-pages:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     # Add a dependency to the build job
     needs: [Jupyter, Pytest]


### PR DESCRIPTION
Potential fix for [https://github.com/DLR-AE/LoadsKernel/security/code-scanning/5](https://github.com/DLR-AE/LoadsKernel/security/code-scanning/5)

In general, to fix this class of issue you explicitly declare a `permissions` block either at the workflow root (so it applies to all jobs by default) or per job, granting only the minimal scopes needed. That prevents the `GITHUB_TOKEN` from inheriting potentially broad repository/organization defaults and documents the workflow’s real requirements.

For this workflow, the `deploy-pages` job already defines its own `permissions`, so the missing piece is `combine-pages`. That job only downloads previously-uploaded artifacts and uploads a pages artifact; it doesn’t push commits, open issues, or manipulate pull requests. The safest fix is to add an explicit, minimal `permissions` block to the `combine-pages` job. Since it interacts with artifacts/Pages infrastructure but not repository contents, we can set `contents: read` (minimal safe baseline) and leave out any write-scoped permissions like `pages: write` (which is only needed in `deploy-pages` and is already specified there). If your repo defaults are already read-only, this change won’t alter behavior; it just makes the restriction explicit and silences the CodeQL warning.

Concretely:
- Edit `.github/workflows/regression-tests.yml`.
- Under the `combine-pages:` job declaration (line 108), add a `permissions:` block before `runs-on: ubuntu-latest`.
- Set `contents: read` as a minimal explicit permission (you can refine later if you know you need additional scopes).

No new imports or additional methods are required; it’s a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
